### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/CompilePDF.yml
+++ b/.github/workflows/CompilePDF.yml
@@ -1,4 +1,6 @@
 name: CompilePDF
+permissions:
+  contents: read
 on:
   push:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/Shaneosaure/DockerSec/security/code-scanning/1](https://github.com/Shaneosaure/DockerSec/security/code-scanning/1)

To fix the problem, add a `permissions:` block that explicitly limits the permissions of the GITHUB_TOKEN for the jobs in this workflow. Since the workflow only checks out code (`actions/checkout`), runs latex compilation, moves files, and uploads them as artifacts (`actions/upload-artifact`), it does not require write access to the repository contents or pull requests. The minimum required for such workflows is usually `contents: read`. Therefore, you should add `permissions: contents: read` at the root level of `.github/workflows/CompilePDF.yml`, just after the `name:` field and before the `on:` field, or directly under the job block (after line 8, before `steps:`). Root-level is preferred so that any future jobs will inherit the appropriate permissions. No imports, dependencies, or further code changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
